### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -2,6 +2,8 @@ name: Format
 on:
   pull_request:
     branches: [main]
+permissions:
+  contents: write
 jobs:
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ItIzYe/Drippy.JS/security/code-scanning/1](https://github.com/ItIzYe/Drippy.JS/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/prettier.yml` at the workflow root so it applies to all jobs in this workflow.  
For this specific workflow, the safest functional fix is:

- `contents: write` (required for committing/pushing formatting changes back to the branch via git-auto-commit action)

This directly addresses the CodeQL finding while preserving behavior (the workflow must still be able to push formatting commits). Place the block after the `on` section and before `jobs` (or before `on`; either is valid YAML). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
